### PR TITLE
feat: make the `podlock.kubewarden.io/profile` immutable

### DIFF
--- a/charts/podlock/README.md
+++ b/charts/podlock/README.md
@@ -1,7 +1,55 @@
 # PodLock
 
-PodLock enforces fine-grained policies on the binaries contained within a container. The processes started from the
-locked binaries are sandboxed, limiting which binaries they can execute and controlling which parts of the container
-filesystem they can read from or can writ to.
+PodLock enforces fine-grained policies on the binaries contained within a container.
+The processes started from the locked binaries are sandboxed, limiting which binaries they can execute and controlling
+which parts of the container filesystem they can read from or write to.
 
 This is achieved using the Landlock Linux Security Module.
+
+## Prerequisites
+
+- Kubernetes 1.25 or later
+- Nodes with Linux kernel supporting Landlock v3 or higher
+- NRI-compatible container runtime (containerd 2.0+ or CRI-O 1.25+)
+- cert-manager (for webhook certificates)
+
+For detailed requirements and setup instructions, see the [full documentation](https://flavio.github.io/podlock/).
+
+## Installation
+
+```bash
+helm repo add podlock https://flavio.github.io/podlock
+helm repo update
+
+helm install podlock podlock/podlock \
+  --namespace podlock \
+  --create-namespace \
+  --wait
+```
+
+## Configuration
+
+Key configuration options available in `values.yaml`:
+
+| Parameter                     | Description                                               | Default                     |
+| ----------------------------- | --------------------------------------------------------- | --------------------------- |
+| `controller.image.repository` | Controller container image repository                     | `flavio/podlock/controller` |
+| `controller.image.tag`        | Controller container image tag                            | `v0.0.1`                    |
+| `controller.replicas`         | Number of controller replicas                             | `1`                         |
+| `controller.resources`        | Controller resource limits and requests                   | See values.yaml             |
+| `nri.image.repository`        | NRI plugin container image repository                     | `flavio/podlock/nri`        |
+| `nri.image.tag`               | NRI plugin container image tag                            | `v0.0.1`                    |
+| `nri.logLevel`                | NRI plugin log level (info, debug, warn, error)           | `info`                      |
+| `nri.resources`               | NRI plugin resource limits and requests                   | See values.yaml             |
+| `vap.enabled`                 | Enable ValidatingAdmissionPolicy for Pod label protection | `true`                      |
+
+### ValidatingAdmissionPolicy
+
+PodLock includes an optional ValidatingAdmissionPolicy that prevents modification of the `podlock.kubewarden.io/profile` label on running Pods,
+ensuring profile bindings remain immutable after Pod creation.
+
+Set `vap.enabled: false` to disable. Requires Kubernetes 1.25 or later.
+
+## Documentation
+
+Visit: **https://flavio.github.io/podlock/**

--- a/charts/podlock/templates/vap/pod-profile-validation.yaml
+++ b/charts/podlock/templates/vap/pod-profile-validation.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.vap.enabled }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  labels:
+    {{- include "podlock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: vap
+  name: {{ include "podlock.fullname" . }}-pod-profile-validation
+  annotations:
+    description: "Validates that podlock.kubewarden.io/profile label cannot be added, removed, or changed during Pod updates"
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["pods"]
+  variables:
+    - name: new_profile
+      expression: |
+        has(object.metadata.labels) && 'podlock.kubewarden.io/profile' in object.metadata.labels 
+        ? object.metadata.labels['podlock.kubewarden.io/profile'] 
+        : null
+    - name: old_profile
+      expression: |
+        has(oldObject.metadata.labels) && 'podlock.kubewarden.io/profile' in oldObject.metadata.labels 
+        ? oldObject.metadata.labels['podlock.kubewarden.io/profile'] 
+        : null
+  validations:
+    - expression: "variables.new_profile == variables.old_profile"
+      message: "The label 'podlock.kubewarden.io/profile' is immutable. You cannot add, remove, or change its value."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  labels:
+    {{- include "podlock.labels" . | nindent 4 }}
+    app.kubernetes.io/component: vap
+  name: {{ include "podlock.fullname" . }}-pod-profile-validation-binding
+  annotations:
+    description: "Binds pod profile validation policy to all Pods"
+spec:
+  policyName: {{ include "podlock.fullname" . }}-pod-profile-validation
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["pods"]
+{{- end }}

--- a/charts/podlock/tests/vap_pod_profile_validation_test.yaml
+++ b/charts/podlock/tests/vap_pod_profile_validation_test.yaml
@@ -1,0 +1,32 @@
+suite: VAP Pod Profile Validation Tests
+templates:
+  - vap/pod-profile-validation.yaml
+tests:
+  - name: VAP resources should be created when enabled
+    set:
+      vap:
+        enabled: true
+    asserts:
+      - isKind:
+          of: ValidatingAdmissionPolicy
+        documentIndex: 0
+      - isKind:
+          of: ValidatingAdmissionPolicyBinding
+        documentIndex: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: ".*-podlock-pod-profile-validation$"
+        documentIndex: 0
+      - matchRegex:
+          path: metadata.name
+          pattern: ".*-podlock-pod-profile-validation-binding$"
+        documentIndex: 1
+
+  - name: VAP resources should not be created when disabled
+    set:
+      vap:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/charts/podlock/values.schema.json
+++ b/charts/podlock/values.schema.json
@@ -112,6 +112,14 @@
                     }
                 }
             }
+        },
+        "vap": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
         }
     }
 }

--- a/charts/podlock/values.yaml
+++ b/charts/podlock/values.yaml
@@ -34,3 +34,8 @@ nri:
     requests:
       cpu: 250m
       memory: 300Mi
+
+# ValidatingAdmissionPolicy for Pod profile validation
+# Requires Kubernetes 1.25+ for ValidatingAdmissionPolicy support
+vap:
+  enabled: true

--- a/docs/next/modules/ROOT/nav.adoc
+++ b/docs/next/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 * xref:index.adoc[Home]
 * xref:quickstart.adoc[]
-* xref:uninstall.adoc[]
 * xref:architecture.adoc[]
+* xref:concepts.adoc[]
+* xref:uninstall.adoc[]

--- a/docs/next/modules/ROOT/pages/concepts.adoc
+++ b/docs/next/modules/ROOT/pages/concepts.adoc
@@ -1,0 +1,39 @@
+= Concepts
+:navtitle: Key Concepts
+
+== Profile Binding to Pods
+
+Profiles cannot be applied to already running Pods. The restrictions are applied
+when the container process is started, so Pods must be created after the profile
+is defined and the label is set.
+
+Moreover, removing or changing the `podlock.kubewarden.io/profile` label on a running
+Pod cannot be done.
+
+This is enforced by a https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/[Validating Admission Policy].
+
+== Container Implications
+
+When a LandlockProfile is applied to a Pod:
+
+* **Containers listed in the profile**: Only the containers explicitly specified in the `spec.profilesByContainer` section of the LandlockProfile will have Landlock restrictions applied. The binaries listed for each container will be intercepted and restricted according to the profile.
+
+* **Containers not listed in the profile**: Containers in the Pod that are not mentioned in the profile will run with no Landlock restrictions applied. This allows you to selectively apply profiles to specific containers within a multi-container Pod.
+
+* **Binaries not listed in the profile**: Within a container that has a profile, any binary not explicitly listed in the profile will run with no restrictions. However, if an unrestricted binary is invoked by a restricted binary, it will inherit the restrictions of the invoking binary.
+
+* **Other pods in the cluster**: Applying a profile to one Pod has no effect on other Pods or Pods running in other namespaces. Each Pod's restrictions are isolated and independent.
+
+== Profile Lifecycle and Deletion Safety
+
+LandlockProfile resources are protected by a finalizer that prevents accidental deletion while they are in use:
+
+* **In-use profiles**: If a LandlockProfile is referenced by a running Pod (via the `podlock.kubewarden.io/profile` label), attempting to delete the profile will not immediately remove it. Instead, the profile will enter a "deletion pending" state with a `DeletionTimestamp` set.
+
+* **Finalizer protection**: The profile's finalizer will remain in place until all Pods referencing the profile have been deleted.
+
+* **Automatic cleanup**: Once all Pods that reference the profile are deleted, the finalizer is removed and the profile is garbage collected.
+
+* **Unreferenced profile deletion**: Profiles that are not referenced by any Pods can be deleted immediately without waiting for finalizer cleanup.
+
+This safety mechanism ensures that security policies cannot be accidentally removed while they are actively protecting running containers.

--- a/docs/next/modules/ROOT/pages/index.adoc
+++ b/docs/next/modules/ROOT/pages/index.adoc
@@ -42,3 +42,6 @@ the system, unless they are under the lib directories (to which it has no write 
 
 Landlock does not require any special privileges to work, so PodLock can be used
 to enforce restrictions even on unprivileged Pods running in restricted environments.
+
+Profiles can be applied to Pods setting the `podlock.kubewarden.io/landlock-profile`
+label to the name of the profile to apply.

--- a/test/e2e/landlock_profile_test.go
+++ b/test/e2e/landlock_profile_test.go
@@ -15,13 +15,9 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 
-	v1alpha1 "github.com/flavio/podlock/api/v1alpha1"
+	"github.com/flavio/podlock/api/v1alpha1"
 	"github.com/flavio/podlock/pkg/constants"
 )
-
-// TODO: currently this test is a bit of a repeting of the controller tests.
-// This is done to have a starting point for e2e tests. In the future, we can
-// expand this with more complex scenarios and remove some of the overlapping tests.
 
 func TestLandlockProfileCreation(t *testing.T) {
 	releaseName := "podlock"

--- a/test/e2e/vap_pod_label_test.go
+++ b/test/e2e/vap_pod_label_test.go
@@ -1,0 +1,371 @@
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
+
+	"github.com/flavio/podlock/api/v1alpha1"
+	"github.com/flavio/podlock/pkg/constants"
+)
+
+func TestValidatingAdmissionPolicyPodProfileLabel(t *testing.T) {
+	releaseName := "podlock"
+	chartPath := "../../charts/podlock"
+	testNamespace := "default"
+	profileName := "pause-profile"
+	vapRejectionMessage := "The label 'podlock.kubewarden.io/profile' is immutable. You cannot add, remove, or change its value."
+
+	f := features.New("Test ValidatingAdmissionPolicy for Pod profile label").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			manager := helm.New(cfg.KubeconfigFile())
+			err := manager.RunInstall(helm.WithName(releaseName),
+				helm.WithNamespace(cfg.Namespace()),
+				helm.WithChart(chartPath),
+				helm.WithWait(),
+				helm.WithArgs("--set", "vap.enabled=true",
+					"--set", "controller.image.tag=latest",
+					"--set", "nri.image.tag=latest",
+					"--set", "nri.logLevel=debug"),
+				helm.WithTimeout("6m"))
+
+			require.NoError(t, err, "podlock helm chart with VAP enabled is not installed correctly")
+
+			return ctx
+		}).
+		Assess("Creating a LandlockProfile for pause container", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			landlockProfile := &v1alpha1.LandlockProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      profileName,
+					Namespace: testNamespace,
+				},
+				Spec: v1alpha1.LandlockProfileSpec{
+					ProfilesByContainer: map[string]v1alpha1.ProfileByBinary{
+						"pause": {
+							"/pause": {},
+						},
+					},
+				},
+			}
+
+			err := cfg.Client().Resources().Create(context.Background(), landlockProfile)
+			require.NoError(t, err, "failed to create LandlockProfile")
+
+			return ctx
+		}).
+		Assess("Adding podlock.kubewarden.io/profile label should be denied", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			podName := "test-pod-add-label"
+
+			// Create pod without label first
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: testNamespace,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "pause",
+						Image: "registry.k8s.io/pause",
+					}},
+				},
+			}
+			err := cfg.Client().Resources().Create(ctx, pod)
+			require.NoError(t, err, "failed to create pod without label")
+
+			// Wait for pod to be running to reduce status update conflicts
+			err = wait.For(conditions.New(cfg.Client().Resources()).PodRunning(pod), wait.WithTimeout(30*time.Second))
+			require.NoError(t, err, "pod failed to reach running state")
+
+			// Try to add label - should be denied by VAP
+			var updateErr error
+			err = wait.For(func(ctx context.Context) (bool, error) {
+				freshPod := &corev1.Pod{}
+				if err := cfg.Client().Resources().Get(ctx, podName, testNamespace, freshPod); err != nil {
+					return false, err
+				}
+				freshPod.Labels = map[string]string{constants.PodProfileLabel: profileName}
+
+				updateErr = cfg.Client().Resources().Update(ctx, freshPod)
+				if updateErr == nil {
+					// Update succeeded - this is unexpected
+					return true, nil
+				}
+				if strings.Contains(updateErr.Error(), "the object has been modified") {
+					// Conflict error - retry
+					return false, nil
+				}
+				// Got a non-conflict error (should be VAP rejection) - done
+				return true, nil
+			}, wait.WithTimeout(30*time.Second), wait.WithInterval(500*time.Millisecond))
+			require.NoError(t, err, "failed waiting for update attempt")
+
+			require.Error(t, updateErr, "expected error when adding podlock profile label")
+			assert.Contains(t, updateErr.Error(), vapRejectionMessage, "error message should match expected admission denial")
+
+			// Clean up
+			err = cfg.Client().Resources().Delete(ctx, pod)
+			assert.NoError(t, err, "failed to cleanup pod")
+
+			return ctx
+		}).
+		Assess("Removing podlock.kubewarden.io/profile label should be denied", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			podName := "test-pod-remove-label"
+
+			// Create pod with label
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						constants.PodProfileLabel: profileName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "pause",
+						Image: "registry.k8s.io/pause",
+					}},
+				},
+			}
+			err := cfg.Client().Resources().Create(ctx, pod)
+			require.NoError(t, err, "failed to create pod with label")
+
+			// Wait for pod to be running to reduce status update conflicts
+			err = wait.For(conditions.New(cfg.Client().Resources()).PodRunning(pod), wait.WithTimeout(30*time.Second))
+			require.NoError(t, err, "pod failed to reach running state")
+
+			// Try to remove label - should be denied by VAP
+			var updateErr error
+			err = wait.For(func(ctx context.Context) (bool, error) {
+				freshPod := &corev1.Pod{}
+				if err := cfg.Client().Resources().Get(ctx, podName, testNamespace, freshPod); err != nil {
+					return false, err
+				}
+
+				updatedPod := freshPod.DeepCopy()
+				delete(updatedPod.Labels, constants.PodProfileLabel)
+
+				updateErr = cfg.Client().Resources().Update(ctx, updatedPod)
+				if updateErr == nil {
+					// Update succeeded - this is unexpected
+					return true, nil
+				}
+				if strings.Contains(updateErr.Error(), "the object has been modified") {
+					// Conflict error - retry
+					return false, nil
+				}
+				// Got a non-conflict error (should be VAP rejection) - done
+				return true, nil
+			}, wait.WithTimeout(30*time.Second), wait.WithInterval(500*time.Millisecond))
+			require.NoError(t, err, "failed waiting for update attempt")
+
+			require.Error(t, updateErr, "expected error when removing podlock profile label")
+			assert.Contains(t, updateErr.Error(), vapRejectionMessage, "error message should match expected admission denial")
+
+			// Clean up
+			pod.Labels = map[string]string{constants.PodProfileLabel: "test-profile"} // restore label for deletion
+			err = cfg.Client().Resources().Delete(ctx, pod)
+			assert.NoError(t, err, "failed to cleanup pod")
+
+			return ctx
+		}).
+		Assess("Changing podlock.kubewarden.io/profile label value should be denied", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			podName := "test-pod-change-label"
+
+			// Create pod with label
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						constants.PodProfileLabel: profileName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "pause",
+						Image: "registry.k8s.io/pause",
+					}},
+				},
+			}
+			err := cfg.Client().Resources().Create(ctx, pod)
+			require.NoError(t, err, "failed to create pod with original label")
+
+			// Wait for pod to be running to reduce status update conflicts
+			err = wait.For(conditions.New(cfg.Client().Resources()).PodRunning(pod), wait.WithTimeout(30*time.Second))
+			require.NoError(t, err, "pod failed to reach running state")
+
+			// Try to change label value - should be denied by VAP
+			var updateErr error
+			err = wait.For(func(ctx context.Context) (bool, error) {
+				freshPod := &corev1.Pod{}
+				if err := cfg.Client().Resources().Get(ctx, podName, testNamespace, freshPod); err != nil {
+					return false, err
+				}
+
+				updatedPod := freshPod.DeepCopy()
+				updatedPod.Labels[constants.PodProfileLabel] = "new-profile"
+
+				updateErr = cfg.Client().Resources().Update(ctx, updatedPod)
+				if updateErr == nil {
+					// Update succeeded - this is unexpected
+					return true, nil
+				}
+				if strings.Contains(updateErr.Error(), "the object has been modified") {
+					// Conflict error - retry
+					return false, nil
+				}
+				// Got a non-conflict error (should be VAP rejection) - done
+				return true, nil
+			}, wait.WithTimeout(30*time.Second), wait.WithInterval(500*time.Millisecond))
+			require.NoError(t, err, "failed waiting for update attempt")
+
+			require.Error(t, updateErr, "expected error when changing podlock profile label value")
+			assert.Contains(t, updateErr.Error(), vapRejectionMessage, "error message should match expected admission denial")
+
+			// Clean up
+			err = cfg.Client().Resources().Delete(ctx, pod)
+			assert.NoError(t, err, "failed to cleanup pod")
+
+			return ctx
+		}).
+		Assess("Updating other Pod fields should be allowed when profile label exists", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			podName := "test-pod-update-fields"
+
+			// Create pod with label
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						constants.PodProfileLabel: profileName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "pause",
+						Image: "registry.k8s.io/pause",
+					}},
+				},
+			}
+			err := cfg.Client().Resources().Create(ctx, pod)
+			require.NoError(t, err, "failed to create pod with label")
+
+			// Wait for pod to be running to reduce status update conflicts
+			err = wait.For(conditions.New(cfg.Client().Resources()).PodRunning(pod), wait.WithTimeout(30*time.Second))
+			require.NoError(t, err, "pod failed to reach running state")
+
+			// Update other fields - should be allowed
+			err = wait.For(func(ctx context.Context) (bool, error) {
+				freshPod := &corev1.Pod{}
+				if err := cfg.Client().Resources().Get(ctx, podName, testNamespace, freshPod); err != nil {
+					return false, err
+				}
+
+				updatedPod := freshPod.DeepCopy()
+				updatedPod.Labels["other-label"] = "other-value"
+				if updatedPod.Annotations == nil {
+					updatedPod.Annotations = make(map[string]string)
+				}
+				updatedPod.Annotations["updated"] = "true"
+
+				updateErr := cfg.Client().Resources().Update(ctx, updatedPod)
+				if updateErr == nil {
+					// Success!
+					return true, nil
+				}
+				if strings.Contains(updateErr.Error(), "the object has been modified") {
+					// Conflict error - retry
+					return false, nil
+				}
+				// Got a non-conflict error - this is unexpected, fail the test
+				return false, updateErr
+			}, wait.WithTimeout(30*time.Second), wait.WithInterval(500*time.Millisecond))
+			require.NoError(t, err, "expected no error when updating other pod fields")
+
+			// Clean up
+			err = cfg.Client().Resources().Delete(ctx, pod)
+			assert.NoError(t, err, "failed to cleanup pod")
+
+			return ctx
+		}).
+		Assess("Updating other Pod fields should be allowed when profile label doesn't exist", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			podName := "test-pod-no-profile-update"
+
+			// Create pod without profile label
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: testNamespace,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "pause",
+						Image: "registry.k8s.io/pause",
+					}},
+				},
+			}
+			err := cfg.Client().Resources().Create(ctx, pod)
+			require.NoError(t, err, "failed to create pod without profile label")
+
+			// Wait for pod to be running to reduce status update conflicts
+			err = wait.For(conditions.New(cfg.Client().Resources()).PodRunning(pod), wait.WithTimeout(30*time.Second))
+			require.NoError(t, err, "pod failed to reach running state")
+
+			// Update other fields - should be allowed
+			err = wait.For(func(ctx context.Context) (bool, error) {
+				freshPod := &corev1.Pod{}
+				if err := cfg.Client().Resources().Get(ctx, podName, testNamespace, freshPod); err != nil {
+					return false, err
+				}
+
+				updatedPod := freshPod.DeepCopy()
+				updatedPod.Labels = map[string]string{"other-label": "other-value"}
+				if updatedPod.Annotations == nil {
+					updatedPod.Annotations = make(map[string]string)
+				}
+				updatedPod.Annotations["updated"] = "true"
+
+				updateErr := cfg.Client().Resources().Update(ctx, updatedPod)
+				if updateErr == nil {
+					// Success!
+					return true, nil
+				}
+				if strings.Contains(updateErr.Error(), "the object has been modified") {
+					// Conflict error - retry
+					return false, nil
+				}
+				// Got a non-conflict error - this is unexpected, fail the test
+				return false, updateErr
+			}, wait.WithTimeout(30*time.Second), wait.WithInterval(500*time.Millisecond))
+			require.NoError(t, err, "expected no error when updating pod without profile label")
+
+			// Clean up
+			err = cfg.Client().Resources().Delete(ctx, pod)
+			assert.NoError(t, err, "failed to cleanup pod")
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			manager := helm.New(cfg.KubeconfigFile())
+			err := manager.RunUninstall(
+				helm.WithName(releaseName),
+				helm.WithNamespace(cfg.Namespace()),
+			)
+			assert.NoError(t, err, "podlock helm chart is not deleted correctly")
+			return ctx
+		})
+
+	testenv.Test(t, f.Feature())
+}


### PR DESCRIPTION
Prevent the `podlock.kubewarden.io/profile` to be changed on a running Pod. This is done with a VAP.
